### PR TITLE
Update to Rocky 8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+puppet/xms-puppet

--- a/README.md
+++ b/README.md
@@ -29,11 +29,11 @@ The containers are setup with puppet almost identically to the real cloud.
 First login to the puppet server and add an entry to the manifest for the
 test node `eximage`.
 ```
-ssh -p 6222 centos@localhost
+ssh -p 6222 rocky@localhost
 ```
 And edit the site manifest:
 ```
-[centos@puppet ~]$ sudo vi /etc/puppetlabs/code/environments/production/manifests/sites.pp
+[rocky@puppet ~]$ sudo vi /etc/puppetlabs/code/environments/production/manifests/sites.pp
 ```
 For example, to add the node to the manifest with the accounts class you would
 add the following:
@@ -43,23 +43,23 @@ node 'eximage' {
 }
 ```
 Then login to eximage. This can be done either with `ssh eximage`
-from inside the container or `ssh -p 6223centos@localhost` from outside.
+from inside the container or `ssh -p 6223 rocky@localhost` from outside.
 Then run puppet on `eximage` to create the certificate:
 ```
-[centos@eximage ~]$ sudo /opt/puppetlabs/bin/puppet agent -t
+[rocky@eximage ~]$ sudo /opt/puppetlabs/bin/puppet agent -t
 ```
-Then back to the puppet server (either `ssh puppet` from inside or `ssh -p 6222 centos@localhost` from outside) and run the following command:
+Then back to the puppet server (either `ssh puppet` from inside or `ssh -p 6222 rocky@localhost` from outside) and run the following command:
 ```
-[centos@puppet ~]$ sudo /opt/puppetlabs/bin/puppetserver ca list
+[rocky@puppet ~]$ sudo /opt/puppetlabs/bin/puppetserver ca list
 ```
 The new VM should be included in the list. Sign the certificate:
 ```
-[centos@puppet ~]$ sudo /opt/puppetlabs/bin/puppetserver ca sign --certname eximage
+[rocky@puppet ~]$ sudo /opt/puppetlabs/bin/puppetserver ca sign --certname eximage
 ```
 
 Then back to the `eximage` to run puppet agent again:
 ```
-[centos@eximage ~]$ sudo /opt/puppetlabs/bin/puppet agent -t
+[rocky@eximage ~]$ sudo /opt/puppetlabs/bin/puppet agent -t
 ```
 
 # Notes

--- a/README.md
+++ b/README.md
@@ -26,40 +26,47 @@ docker-compose up
 
 The containers are setup with puppet almost identically to the real cloud.
 
-First login to the puppet server and add an entry to the manifest for the
-test node `eximage`.
+First login to the puppet server
 ```
 ssh -p 6222 rocky@localhost
 ```
-And edit the site manifest:
+Inside the `puppet` container, edit the site manifest:
 ```
-[rocky@puppet ~]$ sudo vi /etc/puppetlabs/code/environments/production/manifests/sites.pp
+sudo vi /etc/puppetlabs/code/environments/production/manifests/sites.pp
 ```
-For example, to add the node to the manifest with the accounts class you would
+For example, add the node `eximage` to the manifest with the accounts class you would
 add the following:
 ```
 node 'eximage' {
     include accounts
 }
 ```
-Then login to eximage. This can be done either with `ssh eximage`
-from inside the container or `ssh -p 6223 rocky@localhost` from outside.
-Then run puppet on `eximage` to create the certificate:
+Then login to `eximage`. This can be done either with either
 ```
-[rocky@eximage ~]$ sudo /opt/puppetlabs/bin/puppet agent -t
+ssh eximage
 ```
-Then back to the puppet server (either `ssh puppet` from inside or `ssh -p 6222 rocky@localhost` from outside) and run the following command:
+from inside the container or
 ```
-[rocky@puppet ~]$ sudo /opt/puppetlabs/bin/puppetserver ca list
+ssh -p 6223 rocky@localhost
+```
+from outside.
+
+On `eximage`, start the puppet agent to create the certificate:
+```
+sudo /opt/puppetlabs/bin/puppet agent -t
+```
+Then back to the puppet server run the following command:
+```
+sudo /opt/puppetlabs/bin/puppetserver ca list
 ```
 The new VM should be included in the list. Sign the certificate:
 ```
-[rocky@puppet ~]$ sudo /opt/puppetlabs/bin/puppetserver ca sign --certname eximage
+sudo /opt/puppetlabs/bin/puppetserver ca sign --certname eximage
 ```
 
-Then back to the `eximage` to run puppet agent again:
+Back on `eximage`, run the puppet agent again to apply the changes:
 ```
-[rocky@eximage ~]$ sudo /opt/puppetlabs/bin/puppet agent -t
+sudo /opt/puppetlabs/bin/puppet agent -t
 ```
 
 # Notes

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM rockylinux:8.5
+FROM rockylinux:8.8
 COPY . /build
 RUN /build/install.sh && rm -rf /build
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:centos7.9.2009
+FROM rockylinux:8.5
 COPY . /build
 RUN /build/install.sh && rm -rf /build
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh

--- a/base/base.config
+++ b/base/base.config
@@ -1,3 +1,3 @@
 GOSU_VERSION=1.12
-ADMIN_USER="centos"
+ADMIN_USER="rocky"
 ADMIN_PASSWD="test123"

--- a/base/install.sh
+++ b/base/install.sh
@@ -38,13 +38,11 @@ ssh-keygen -t ed25519 -N '' -f /etc/ssh/ssh_host_ed25519_key
 chgrp ssh_keys /etc/ssh/ssh_host_rsa_key
 chgrp ssh_keys /etc/ssh/ssh_host_ecdsa_key
 chgrp ssh_keys /etc/ssh/ssh_host_ed25519_key
-
 rm -f /var/run/nologin
 
 #------------------------
 # Setup user accounts
 #------------------------
-
 useradd -ms /bin/bash $ADMIN_USER
 echo $ADMIN_PASSWD | passwd --stdin $ADMIN_USER
 idnumber=`id -u $ADMIN_USER`
@@ -78,7 +76,7 @@ openssl genrsa -out /etc/pki/tls/ca.key 4096
 openssl req -new -x509 -days 3650 -sha256 -key /etc/pki/tls/ca.key -extensions v3_ca -out /etc/pki/tls/ca.crt -subj "/CN=fake-ca"
 # Generate certificate request
 openssl genrsa -out /etc/pki/tls/private/localhost.key 2048
-openssl req -new -sha256 -key /etc/pki/tls/private/localhost.key -out /etc/pki/tls/certs/localhost.csr -subj "/C=US/ST=NY/O=HPC Tutorial/CN=localhost"
+openssl req -new -sha256 -key /etc/pki/tls/private/localhost.key -out /etc/pki/tls/certs/localhost.csr -subj "/C=US/ST=NY/O=Puppet Test/CN=localhost"
 # Config for signing cert
 cat > /etc/pki/tls/localhost.ext << EOF
 authorityKeyIdentifier=keyid,issuer
@@ -95,8 +93,8 @@ openssl x509 -req -CA /etc/pki/tls/ca.crt -CAkey /etc/pki/tls/ca.key -CAcreatese
 cp /etc/pki/tls/ca.crt /etc/pki/ca-trust/source/anchors/
 update-ca-trust extract
 
-yum install -y https://yum.puppet.com/puppet6-release-el-8.noarch.rpm
-yum install -y puppet-agent
-
-yum clean all
-rm -rf /var/cache/yum
+# Install puppet and puppet agent
+dnf install -y https://yum.puppet.com/puppet6-release-el-8.noarch.rpm
+dnf install -y puppet-agent
+dnf clean all
+rm -rf /var/cache/dnf

--- a/base/install.sh
+++ b/base/install.sh
@@ -16,7 +16,7 @@ GOSU_VERSION=${GOSU_VERSION:-1.12}
 # Install base packages
 #------------------------
 log_info "Installing base packages.."
-yum install -y \
+dnf install -y \
     openssh-server \
     openssh-clients \
     sudo \
@@ -25,7 +25,8 @@ yum install -y \
     vim \
     authconfig \
     openssl \
-    bash-completion
+    bash-completion \
+    passwd
 
 #------------------------
 # Generate ssh host keys
@@ -37,6 +38,8 @@ ssh-keygen -t ed25519 -N '' -f /etc/ssh/ssh_host_ed25519_key
 chgrp ssh_keys /etc/ssh/ssh_host_rsa_key
 chgrp ssh_keys /etc/ssh/ssh_host_ecdsa_key
 chgrp ssh_keys /etc/ssh/ssh_host_ed25519_key
+
+rm -f /var/run/nologin
 
 #------------------------
 # Setup user accounts
@@ -92,8 +95,8 @@ openssl x509 -req -CA /etc/pki/tls/ca.crt -CAkey /etc/pki/tls/ca.key -CAcreatese
 cp /etc/pki/tls/ca.crt /etc/pki/ca-trust/source/anchors/
 update-ca-trust extract
 
-yum install -y https://yum.puppet.com/puppet6-release-el-7.noarch.rpm
-yum -y install puppet-agent
+yum install -y https://yum.puppet.com/puppet6-release-el-8.noarch.rpm
+yum install -y puppet-agent
 
 yum clean all
 rm -rf /var/cache/yum

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.8"
 
 services:
   eximage:
-    image: joetest:base-${PTEST_VERSION}
+    image: puppettest:base-${PTEST_VERSION}
     build:
       context: ./base
     command: ["serve"]
@@ -16,7 +16,7 @@ services:
       - "127.0.0.1:6223:22"
 
   puppet:
-    image: joetest:puppet-${PTEST_VERSION}
+    image: puppettest:puppet-${PTEST_VERSION}
     build:
       context: ./puppet
       args:

--- a/puppet/Dockerfile
+++ b/puppet/Dockerfile
@@ -1,6 +1,6 @@
 ARG PTEST_VERSION
 FROM puppettest:base-${PTEST_VERSION}
-RUN yum install -y puppetserver
+RUN dnf install -y puppetserver
 RUN sed -i 's/-Xms2g -Xmx2g/-Xms1g -Xmx1g/' /etc/sysconfig/puppetserver
 COPY ./xms-puppet/code /etc/puppetlabs/code
 COPY ./xms-puppet/bin/install-modules.sh /usr/local/bin/install-modules.sh

--- a/puppet/Dockerfile
+++ b/puppet/Dockerfile
@@ -1,5 +1,5 @@
 ARG PTEST_VERSION
-FROM joetest:base-${PTEST_VERSION}
+FROM puppettest:base-${PTEST_VERSION}
 RUN yum install -y puppetserver
 RUN sed -i 's/-Xms2g -Xmx2g/-Xms1g -Xmx1g/' /etc/sysconfig/puppetserver
 COPY ./xms-puppet/code /etc/puppetlabs/code


### PR DESCRIPTION
This PR updates the base image from Centos 7.9 to Rocky 8.8. There are also some minor updates to the README.

Tested by following the exact instructions in the README.